### PR TITLE
Functionality for adding feast manually via modal as of #50

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -18,6 +18,14 @@ hymns = [('', 'None')] + [(h.ref, f'{h.ref} - {h.title}') for h in
 translations = [('', 'None')] + [(h.translation, f'{h.translation}') for h in
                           Music.neh_hymns()]
 
+class FeastForm(Form):
+    # Required fields
+    name = StringField('Name', validators=[DataRequired()])
+    month = StringField('Month', validators=[DataRequired()])
+    day = StringField('Day', validators=[DataRequired()])
+    collect = StringField('Collect', widget=TextArea(), validators=[DataRequired()])
+    # Optional fields
+
 class AnthemForm(Form):
     title = StringField('Anthem')
     composer = StringField('Anthem composer')

--- a/forms.py
+++ b/forms.py
@@ -1,9 +1,10 @@
 from flask import request
-from flask_wtf import FlaskForm
+from flask_wtf import FlaskForm, Form
 from wtforms import DateField, HiddenField, SelectField, SelectMultipleField, \
     StringField
 from wtforms import (
     TimeField,
+    FormField
 )
 from wtforms.validators import DataRequired
 from wtforms.widgets import TextArea
@@ -16,6 +17,11 @@ hymns = [('', 'None')] + [(h.ref, f'{h.ref} - {h.title}') for h in
 translations = [('', 'None')] + [(h.translation, f'{h.translation}') for h in
                           Music.neh_hymns()]
 
+class AnthemForm(Form):
+    title = StringField('Anthem')
+    composer = StringField('Anthem composer')
+    lyrics = StringField('Anthem lyrics', widget=TextArea())
+    translation = SelectField('Anthem Translation', choices=translations)
 
 class PewSheetForm(FlaskForm):
     title = HiddenField('Title')
@@ -38,10 +44,7 @@ class PewSheetForm(FlaskForm):
     offertory_hymn = SelectField('Offertory Hymn', choices=hymns)
     recessional_hymn = SelectField('Recessional Hymn', choices=hymns)
 
-    anthem_title = StringField('Anthem')
-    anthem_composer = StringField('Anthem composer')
-    anthem_lyrics = StringField('Anthem lyrics', widget=TextArea())
-    anthem_translation = SelectField('Anthem Translation', choices=translations)
+    anthem_group = FormField(AnthemForm)
 
     class Meta:
         csrf = False

--- a/forms.py
+++ b/forms.py
@@ -29,6 +29,7 @@ class FeastForm(FlaskForm):
     offertory = StringField('Offertory', widget=TextArea())
     tract = StringField('Tract', widget=TextArea())
     gradual = StringField('Gradual', widget=TextArea())
+    alleluia = StringField('Alleluia', widget=TextArea())
 
 class AnthemForm(Form):
     title = StringField('Anthem')

--- a/forms.py
+++ b/forms.py
@@ -41,12 +41,12 @@ class PewSheetForm(FlaskForm):
     feasts = Feast.upcoming()
     feast_choices = [(feast.slug, feast.name) for feast in feasts]
     primary_feast = SelectField(
-        'Primary Feast',
+        'Primary Feast',  #choices=[]
         choices=feast_choices,
     )
     secondary_feasts = SelectMultipleField(
         'Secondary Feasts',
-        choices=[('', '')] + feast_choices,
+        choices=[('', '')] + feast_choices, validate_choice=False
     )
     date = DateField('Date', validators=[DataRequired()])
     time = TimeField('Time', validators=[DataRequired()])

--- a/forms.py
+++ b/forms.py
@@ -18,13 +18,17 @@ hymns = [('', 'None')] + [(h.ref, f'{h.ref} - {h.title}') for h in
 translations = [('', 'None')] + [(h.translation, f'{h.translation}') for h in
                           Music.neh_hymns()]
 
-class FeastForm(Form):
+class FeastForm(FlaskForm):
     # Required fields
     name = StringField('Name', validators=[DataRequired()])
     month = StringField('Month', validators=[DataRequired()])
     day = StringField('Day', validators=[DataRequired()])
     collect = StringField('Collect', widget=TextArea(), validators=[DataRequired()])
     # Optional fields
+    introit = StringField('Introit', widget=TextArea())
+    offertory = StringField('Offertory', widget=TextArea())
+    tract = StringField('Tract', widget=TextArea())
+    gradual = StringField('Gradual', widget=TextArea())
 
 class AnthemForm(Form):
     title = StringField('Anthem')

--- a/forms.py
+++ b/forms.py
@@ -13,6 +13,9 @@ from models import Feast, Music
 hymns = [('', 'None')] + [(h.ref, f'{h.ref} - {h.title}') for h in
                           Music.neh_hymns()]
 
+translations = [('', 'None')] + [(h.translation, f'{h.translation}') for h in
+                          Music.neh_hymns()]
+
 
 class PewSheetForm(FlaskForm):
     title = HiddenField('Title')
@@ -38,6 +41,7 @@ class PewSheetForm(FlaskForm):
     anthem_title = StringField('Anthem')
     anthem_composer = StringField('Anthem composer')
     anthem_lyrics = StringField('Anthem lyrics', widget=TextArea())
+    anthem_translation = SelectField('Anthem Translation', choices=translations)
 
     class Meta:
         csrf = False

--- a/models.py
+++ b/models.py
@@ -440,7 +440,7 @@ class Service:
         else:
             secondary_feasts = []
 
-        if form.anthem_title.data or form.anthem_composer.data or form.anthem_lyrics.data:
+        if form.anthem_title.data or form.anthem_composer.data or form.anthem_lyrics.data or form.anthem_translation.data:
             anthem = Music(
                 title=form.anthem_title.data,
                 composer=form.anthem_composer.data,
@@ -451,8 +451,6 @@ class Service:
             )
         else:
             anthem = None
-
-        print(form.anthem_translation.data)
 
         return Service(
             title=form.title.data,

--- a/models.py
+++ b/models.py
@@ -17,7 +17,7 @@ from docxtpl import DocxTemplate, RichText
 from models_base import get
 
 if typing.TYPE_CHECKING:
-    from forms import PewSheetForm, AnthemForm
+    from forms import PewSheetForm, AnthemForm, FeastForm
 
 from utils import get_neh_df, advent, closest_sunday_to, NoPandasError, logger
 
@@ -41,6 +41,17 @@ class Feast:
     @classmethod
     def from_yaml(cls, slug):
         return _feast_from_yaml(slug)
+    
+    @classmethod
+    def to_yaml(cls, feastForm: 'FeastForm'):
+        with open((DATA_DIR / feastForm.name.data).with_suffix('.yaml'), "w") as f:
+            f.write('name: ' + feastForm.name.data + '\n')
+            #TODO: check validity of day and month, 
+            # i.e. generate Date instance with Date(str) and check if it exists
+            f.write('month: ' + feastForm.month.data + '\n')
+            f.write('day: ' + feastForm.day.data + '\n')
+            f.write('collect: ' + feastForm.collect.data + '\n')
+
 
     @classmethod
     def all(cls):

--- a/models.py
+++ b/models.py
@@ -51,6 +51,10 @@ class Feast:
             f.write('month: ' + feastForm.month.data + '\n')
             f.write('day: ' + feastForm.day.data + '\n')
             f.write('collect: ' + feastForm.collect.data + '\n')
+            f.write('introit: ' + feastForm.introit.data + '\n')
+            f.write('gradual: ' + feastForm.gradual.data + '\n')
+            f.write('tract: ' + feastForm.tract.data + '\n')
+            f.write('offertory: ' + feastForm.offertory.data + '\n')
 
 
     @classmethod

--- a/models.py
+++ b/models.py
@@ -182,6 +182,7 @@ class Music:
     composer: Optional[str] = field()
     lyrics: Optional[str] = field()
     ref: Optional[str] = field()
+    translation: Optional[str] = field()
 
     @classmethod
     def neh_hymns(cls) -> List['Music']:
@@ -203,7 +204,8 @@ class Music:
                 category='Hymn',
                 composer=None,
                 lyrics=None,
-                ref=f'NEH: {record.number}'
+                ref=f'NEH: {record.number}',
+                translation=f'Words/translation available at NEH: {record.number}, {record.firstLine}'
             ) for record in records
         ]
         hymns.sort(key=lambda m: nehref2num(m.ref or ""))
@@ -419,7 +421,7 @@ class Service:
 
         if self.anthem:
             items.append(
-                ServiceItem('Anthem', [self.anthem.lyrics],
+                ServiceItem('Anthem', [self.anthem.lyrics, self.anthem.translation],
                             f'{self.anthem.title}. {self.anthem.composer}'))
 
         if self.recessional_hymn:
@@ -444,10 +446,13 @@ class Service:
                 composer=form.anthem_composer.data,
                 lyrics=form.anthem_lyrics.data,
                 category='Anthem',
-                ref=None
+                ref=None,
+                translation=form.anthem_translation.data
             )
         else:
             anthem = None
+
+        print(form.anthem_translation.data)
 
         return Service(
             title=form.title.data,

--- a/models.py
+++ b/models.py
@@ -38,6 +38,21 @@ def _none2datemax(d: Optional[dt.date]) -> dt.date:
 
 @define
 class Feast:
+    optionalFields = ['introit', 'gat', 'gradual', 'alleluia', 'tract', 'offertory']
+
+    def infer_gat(gradual, alleluia):
+        gat = None
+        if gradual:
+            gat = 'Gradual'
+        if alleluia:
+            if gat is not None:
+                gat = gat + ' and Alleuia'
+            else:
+                gat = 'Alleuia'
+        if gat is not None:
+            gat = gat + ' Proper'
+        return gat
+
     @classmethod
     def from_yaml(cls, slug):
         return _feast_from_yaml(slug)
@@ -45,6 +60,7 @@ class Feast:
     @classmethod
     def to_yaml(cls, feastForm: 'FeastForm'):
         name = formatFeastName(feastForm.name.data)
+        gat = cls.infer_gat(feastForm.gradual.data, feastForm.alleluia.data)
         with open((DATA_DIR / name).with_suffix('.yaml'), "w") as f:
             f.write('name: ' + feastForm.name.data + '\n')
             #TODO: check validity of day and month, 
@@ -52,10 +68,14 @@ class Feast:
             f.write('month: ' + feastForm.month.data + '\n')
             f.write('day: ' + feastForm.day.data + '\n')
             f.write('collect: ' + feastForm.collect.data + '\n')
-            f.write('introit: ' + feastForm.introit.data + '\n')
-            f.write('gradual: ' + feastForm.gradual.data + '\n')
-            f.write('tract: ' + feastForm.tract.data + '\n')
-            f.write('offertory: ' + feastForm.offertory.data + '\n')
+            for field in cls.optionalFields:
+                if field != 'gat':
+                    if feastForm[field].data:
+                        f.write(field + ': ' + feastForm[field].data + '\n')
+                else:
+                    if gat is not None:
+                        f.write('gat: ' + gat + '\n')
+
         with open(DATA_DIR / '_list.txt', "a") as f:
             f.write('\n' + name)
 

--- a/models.py
+++ b/models.py
@@ -19,7 +19,7 @@ from models_base import get
 if typing.TYPE_CHECKING:
     from forms import PewSheetForm, AnthemForm, FeastForm
 
-from utils import get_neh_df, advent, closest_sunday_to, NoPandasError, logger
+from utils import get_neh_df, advent, closest_sunday_to, NoPandasError, logger, formatFeastName
 
 feasts_fields = ['name', 'month', 'day', 'coeaster', 'coadvent',
                  'introit', 'collect', 'epistle_ref', 'epistle',
@@ -44,7 +44,8 @@ class Feast:
     
     @classmethod
     def to_yaml(cls, feastForm: 'FeastForm'):
-        with open((DATA_DIR / feastForm.name.data).with_suffix('.yaml'), "w") as f:
+        name = formatFeastName(feastForm.name.data)
+        with open((DATA_DIR / name).with_suffix('.yaml'), "w") as f:
             f.write('name: ' + feastForm.name.data + '\n')
             #TODO: check validity of day and month, 
             # i.e. generate Date instance with Date(str) and check if it exists
@@ -55,6 +56,9 @@ class Feast:
             f.write('gradual: ' + feastForm.gradual.data + '\n')
             f.write('tract: ' + feastForm.tract.data + '\n')
             f.write('offertory: ' + feastForm.offertory.data + '\n')
+        with open(DATA_DIR / '_list.txt', "a") as f:
+            f.write('\n' + name)
+
 
 
     @classmethod

--- a/models.py
+++ b/models.py
@@ -17,7 +17,7 @@ from docxtpl import DocxTemplate, RichText
 from models_base import get
 
 if typing.TYPE_CHECKING:
-    from forms import PewSheetForm
+    from forms import PewSheetForm, AnthemForm
 
 from utils import get_neh_df, advent, closest_sunday_to, NoPandasError, logger
 
@@ -440,14 +440,15 @@ class Service:
         else:
             secondary_feasts = []
 
-        if form.anthem_title.data or form.anthem_composer.data or form.anthem_lyrics.data or form.anthem_translation.data:
+        if form.anthem_group.data:
+            ag = form.anthem_group
             anthem = Music(
-                title=form.anthem_title.data,
-                composer=form.anthem_composer.data,
-                lyrics=form.anthem_lyrics.data,
+                title=ag.title.data,
+                composer=ag.composer.data,
+                lyrics=ag.lyrics.data,
                 category='Anthem',
                 ref=None,
-                translation=form.anthem_translation.data
+                translation=ag.translation.data
             )
         else:
             anthem = None

--- a/pypew.py
+++ b/pypew.py
@@ -13,6 +13,8 @@ import filters
 import views
 from utils import logger
 
+from flask_wtf.csrf import CSRFProtect
+
 load_dotenv()
 
 
@@ -102,6 +104,7 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
 
     pypew = PyPew()
     app = create_app(pypew)
+    csrf = CSRFProtect(app)
 
     if args.debug:
         # noinspection FlaskDebugMode

--- a/pypew.py
+++ b/pypew.py
@@ -124,5 +124,4 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
 
 
 if __name__ == '__main__':
-    print('some test');
     main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,6 @@ python-dotenv~=0.21.0
 python-slugify~=7.0.0
 PyYAML~=6.0
 WTForms~=3.0.1
-setuptools~=50.3.2
+setuptools~=71.1.0
 openpyxl==3.0.9
 Werkzeug~=2.2.2

--- a/static/serviceForm.js
+++ b/static/serviceForm.js
@@ -63,28 +63,6 @@ nextWeekBtn.onclick = () => {
   dateField.value = toISO(new Date(nextWeek));
 };
 
-const dialog = document.getElementById("feast-dialog");
-const addFeastBtn = document.getElementById('add-feast-dialog');
-addFeastBtn.onclick = () => {
-  dialog.showModal();
-};
-
-const cancelButton = document.getElementById("cancel");
-cancelButton.onclick = () => {
-  dialog.close("Feast creation cancelled");
-};
-
-const createFeastBtn = document.getElementById("create-feast");
-createFeastBtn.onclick = () => {
-  const feastName = document.getElementById("feast-name");
-  dialog.close("Feast created successfully");
-};
-
-dialog.addEventListener('close', function(e){
-  e.preventDefault();
-  console.log(dialog.returnValue);
-});
-
 
 /**
  * Cause a class to be applied to the specified fields when the

--- a/static/serviceForm.js
+++ b/static/serviceForm.js
@@ -71,13 +71,13 @@ addFeastBtn.onclick = () => {
 
 const cancelButton = document.getElementById("cancel");
 cancelButton.onclick = () => {
-  dialog.close("feastCreationCancelled");
+  dialog.close("Feast creation cancelled");
 };
 
 const createFeastBtn = document.getElementById("create-feast");
 createFeastBtn.onclick = () => {
   const feastName = document.getElementById("feast-name");
-  dialog.close(feastName.value);
+  dialog.close("Feast created successfully");
 };
 
 dialog.addEventListener('close', function(e){

--- a/templates/createFeast.html
+++ b/templates/createFeast.html
@@ -1,0 +1,52 @@
+<div class="row mb-3">
+    {{ feastForm.name.label(class='col-sm-2 col-form-label') }}
+    <div class="col-sm-5">
+        {{ feastForm.name(class='form-control') }}
+        {% if feastForm.name.errors %}
+            {% for error in feastForm.name.errors %}
+                <small class="font-small text-danger">
+                    {{ error }}
+                </small>
+            {% endfor %}
+        {% endif %}
+    </div>
+</div>
+<div class="row mb-3">
+    {{ feastForm.day.label(class='col-sm-1 col-form-label') }}
+    <div class="col">
+        {{ feastForm.day(class='form-control') }}
+        {% if feastForm.day.errors %}
+            {% for error in feastForm.day.errors %}
+                <small class="font-small text-danger">
+                    {{ error }}
+                </small>
+            {% endfor %}
+        {% endif %}
+    </div>
+</div>
+<div class="row mb-3">
+    {{ feastForm.month.label(class='col-sm-1 col-form-label') }}
+    <div class="col">
+        {{ feastForm.month(class='form-control') }}
+        {% if feastForm.month.errors %}
+            {% for error in feastForm.month.errors %}
+                <small class="font-small text-danger">
+                    {{ error }}
+                </small>
+            {% endfor %}
+        {% endif %}
+    </div>
+</div>
+<div class="row mb-3">
+    {{ feastForm.collect.label(class='col-sm-2 col-form-label') }}
+    <div class="col-sm-5">
+        {{ feastForm.collect(class='form-control') }}
+        {% if feastForm.collect.errors %}
+            {% for error in feastForm.collect.errors %}
+                <small class="font-small text-danger">
+                    {{ error }}
+                </small>
+            {% endfor %}
+        {% endif %}
+    </div>
+</div>

--- a/templates/createFeast.html
+++ b/templates/createFeast.html
@@ -1,4 +1,4 @@
-<form method="get" action="{{ url_for('create_feast') }}">
+<form method="get" id="createFeastForm" action="{{ url_for('create_feast') }}">
     {{ form.hidden_tag() }}
     {% for field in feastFormFields %}
         <div class="row">
@@ -6,7 +6,7 @@
                 {{ feastForm[field].label(class='col-form-label') }}
             </div>
             <div class="col-sm-9">
-                {{ feastForm[field](class='form-control') }}
+                {{ feastForm[field](class='form-control', id='feast-' + field) }}
                 {% if feastForm[field].errors %}
                     {% for error in feastForm[field].errors %}
                         <small class="font-small text-danger">

--- a/templates/createFeast.html
+++ b/templates/createFeast.html
@@ -1,5 +1,5 @@
 <form method="get" id="createFeastForm" action="{{ url_for('create_feast') }}">
-    {{ form.hidden_tag() }}
+    {{ feastForm.csrf_token }}
     {% for field in feastFormFields %}
         <div class="row">
             <div class="col-sm-3">

--- a/templates/createFeast.html
+++ b/templates/createFeast.html
@@ -1,52 +1,24 @@
-<div class="row mb-3">
-    {{ feastForm.name.label(class='col-sm-2 col-form-label') }}
-    <div class="col-sm-5">
-        {{ feastForm.name(class='form-control') }}
-        {% if feastForm.name.errors %}
-            {% for error in feastForm.name.errors %}
-                <small class="font-small text-danger">
-                    {{ error }}
-                </small>
-            {% endfor %}
-        {% endif %}
+<form method="get" action="{{ url_for('create_feast') }}">
+    {{ form.hidden_tag() }}
+    {% for field in feastFormFields %}
+        <div class="row">
+            <div class="col-sm-3">
+                {{ feastForm[field].label(class='col-form-label') }}
+            </div>
+            <div class="col-sm-9">
+                {{ feastForm[field](class='form-control') }}
+                {% if feastForm[field].errors %}
+                    {% for error in feastForm[field].errors %}
+                        <small class="font-small text-danger">
+                            {{ error }}
+                        </small>
+                    {% endfor %}
+                {% endif %}
+            </div>
+        </div>
+    {% endfor %}
+    <div>
+        <button id="cancel" type="reset">Cancel</button>
+        <input id="create-feast" type="submit" value="Create Feast">
     </div>
-</div>
-<div class="row mb-3">
-    {{ feastForm.day.label(class='col-sm-1 col-form-label') }}
-    <div class="col">
-        {{ feastForm.day(class='form-control') }}
-        {% if feastForm.day.errors %}
-            {% for error in feastForm.day.errors %}
-                <small class="font-small text-danger">
-                    {{ error }}
-                </small>
-            {% endfor %}
-        {% endif %}
-    </div>
-</div>
-<div class="row mb-3">
-    {{ feastForm.month.label(class='col-sm-1 col-form-label') }}
-    <div class="col">
-        {{ feastForm.month(class='form-control') }}
-        {% if feastForm.month.errors %}
-            {% for error in feastForm.month.errors %}
-                <small class="font-small text-danger">
-                    {{ error }}
-                </small>
-            {% endfor %}
-        {% endif %}
-    </div>
-</div>
-<div class="row mb-3">
-    {{ feastForm.collect.label(class='col-sm-2 col-form-label') }}
-    <div class="col-sm-5">
-        {{ feastForm.collect(class='form-control') }}
-        {% if feastForm.collect.errors %}
-            {% for error in feastForm.collect.errors %}
-                <small class="font-small text-danger">
-                    {{ error }}
-                </small>
-            {% endfor %}
-        {% endif %}
-    </div>
-</div>
+</form>

--- a/templates/serviceForm.html
+++ b/templates/serviceForm.html
@@ -192,11 +192,51 @@
 
     // Note: logic needs to be able to access python API and hence was placed here
     var feastsArray = [];
+    var monthNames = [ "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December" ]; 
+    // source: https://www.freecodecamp.org/news/format-dates-with-ordinal-number-suffixes-javascript/
+    const nthNumber = (number) => {
+        if (number > 3 && number < 21) return "th";
+        switch (number % 10) {
+            case 1:
+            return "st";
+            case 2:
+            return "nd";
+            case 3:
+            return "rd";
+            default:
+            return "th";
+        }
+    };
     var feastName = document.getElementById("feast-name");
     var feastDay = document.getElementById("feast-day");
     var feastMonth = document.getElementById("feast-month");
     feastName.addEventListener('change', checkForNameDuplicates);
-    //TODO: check date duplicates
+    feastDay.addEventListener('change', checkForDateDuplicates);
+    feastMonth.addEventListener('change', checkForDateDuplicates);
+    
+    function checkForDateDuplicates() {
+        var day = feastDay.value? parseInt(feastDay.value) : 0;
+        var month = feastMonth.value? parseInt(feastMonth.value): 0;
+        if(day == 0 || month == 0){
+            return;
+        }
+        console.log(nthNumber(day) + ', ' + monthNames[month-1]);
+        var similarityDetected = false;
+        feastsArray.every(function (el) {
+            // compare date of feast to input month and day
+            var dateComponents = el.next.split(' ');
+            if(dateComponents.length == 4 && (day + nthNumber(day) == dateComponents[1]) && monthNames[month-1] == dateComponents[2]){
+                similarityDetected = true;
+                return false;
+            }
+            
+            return true;
+        });
+
+        if (similarityDetected) {
+            alert("You're creating a feast for " + day + "." + month + "., but there already exists a feast on this date; are you accidentally creating a duplicate?");
+        }
+    }
 
     function checkForNameDuplicates() {
         var input = feastName.value;

--- a/templates/serviceForm.html
+++ b/templates/serviceForm.html
@@ -1,11 +1,5 @@
 <dialog id="feast-dialog">
-    <form method="get" action="{{ url_for('create_feast') }}">
-        {% include "createFeast.html" %}
-      <div>
-        <button id="cancel" type="reset">Cancel</button>
-        <input id="create-feast" type="submit" value="Create Feast">
-      </div>
-    </form>
+    {% include "createFeast.html" %}
 </dialog>
 <form action="{{ url_for('pew_sheet_create_view') }}"
       class="px-5">

--- a/templates/serviceForm.html
+++ b/templates/serviceForm.html
@@ -35,7 +35,7 @@
     <div class="row mb-3">
         {{ form.secondary_feasts.label(class='col-sm-2 col-form-label') }}
         <div class="col-sm-5">
-            {{ form.secondary_feasts(class='form-select') }}
+            {{ form.secondary_feasts(class='form-select', formnovalidate=True) }}
             {% if form.secondary_feasts.errors %}
                 {% for error in form.secondary_feasts.errors %}
                     <small class="font-small text-danger">
@@ -188,3 +188,53 @@
 </form>
 
 <script src="{{ url_for('static', filename='serviceForm.js') }}"></script>
+<script>
+
+    // Note: logic needs to be able to access python API and hence was placed here
+
+    const dialog = document.getElementById("feast-dialog");
+    const addFeastBtn = document.getElementById('add-feast-dialog');
+    addFeastBtn.onclick = () => {
+        dialog.showModal();
+    };
+
+    const cancelButton = document.getElementById("cancel");
+    cancelButton.onclick = () => {
+        var feastName = document.getElementById("feast-name");
+        dialog.close("Feast creation cancelled");
+    };
+
+    function updateFeasts(){
+        // refresh feasts
+        console.log('retrieved data from database');
+        const feastsApiUrl = "{{ url_for('feast_upcoming_api') }}";
+        const feastsArray = fetch(feastsApiUrl).then(response => response.json())
+        .then(function(response) {
+            console.log("Nr. of feasts: " + response.length);
+            console.log(JSON.stringify(response));
+            // clear choice options
+            var secondaryFeastsField = document.getElementById('secondary_feasts');
+            secondaryFeastsField.replaceChildren();
+            // recreate choice options
+            response.forEach(element => {
+                var opt = document.createElement('option');
+                opt.text = element.name;
+                opt.value = element.slug;
+                secondaryFeastsField.add(opt);
+            });
+        });
+    }
+    // TODO: update feasts also for newly opened pew sheet form
+
+    const createFeastBtn = document.getElementById("create-feast");
+    createFeastBtn.onclick = () => {
+        dialog.close("Feast creation request submitted!");
+        // wait some time for database update
+        const myTimeout = setTimeout(updateFeasts, 2000);
+    };
+
+    dialog.addEventListener('close', function (e) {
+        e.preventDefault();
+        console.log(dialog.returnValue);
+    });  
+</script>

--- a/templates/serviceForm.html
+++ b/templates/serviceForm.html
@@ -136,6 +136,20 @@
     </div>
 
     <div class="row mb-3">
+        {{ form.anthem_translation.label(class='col-sm-2 col-form-label') }}
+        <div class="col-sm-5">
+            {{ form.anthem_translation(class='form-control') }}
+            {% if form.anthem_translation.errors %}
+                {% for error in form.anthem_translation.errors %}
+                    <small class="font-small text-danger">
+                        {{ error }}
+                    </small>
+                {% endfor %}
+            {% endif %}
+        </div>
+    </div>
+
+    <div class="row mb-3">
         {{ form.anthem_composer.label(class='col-sm-2 col-form-label') }}
         <div class="col-sm-5">
             {{ form.anthem_composer(class='form-control') }}

--- a/templates/serviceForm.html
+++ b/templates/serviceForm.html
@@ -191,6 +191,43 @@
 <script>
 
     // Note: logic needs to be able to access python API and hence was placed here
+    var feastsArray = [];
+    var feastName = document.getElementById("feast-name");
+    var feastDay = document.getElementById("feast-day");
+    var feastMonth = document.getElementById("feast-month");
+    feastName.addEventListener('change', checkForNameDuplicates);
+    //TODO: check date duplicates
+
+    function checkForNameDuplicates() {
+        var input = feastName.value;
+        var words = input.split(' ');
+        var similarityCt = 0, similarFeast = '';
+        feastsArray.every(function (el) {
+            if (similarityCt > 1) {
+                return false;
+            }
+            similarityCt = 0;
+            words.every(function (word) {
+                if (similarityCt > 1) {
+                    return false;
+                }
+                if (el.name.includes(word)) {
+                    if (word != 'and') {
+                        similarityCt++;
+                    }
+                    if(similarityCt == 2){
+                        similarFeast = el.name;
+                    }
+                }
+                return true;
+            });
+            return true;
+        });
+
+        if (similarityCt > 1) {
+            alert("You're inputting " + input + ", but " + similarFeast + " already exists; are you accidentally creating a duplicate?");
+        }
+    }
 
     const dialog = document.getElementById("feast-dialog");
     const addFeastBtn = document.getElementById('add-feast-dialog');
@@ -200,7 +237,6 @@
 
     const cancelButton = document.getElementById("cancel");
     cancelButton.onclick = () => {
-        var feastName = document.getElementById("feast-name");
         dialog.close("Feast creation cancelled");
     };
 
@@ -208,10 +244,8 @@
         // refresh feasts
         console.log('retrieved data from database');
         const feastsApiUrl = "{{ url_for('feast_upcoming_api') }}";
-        const feastsArray = fetch(feastsApiUrl).then(response => response.json())
+        fetch(feastsApiUrl).then(response => response.json())
         .then(function(response) {
-            console.log("Nr. of feasts: " + response.length);
-            console.log(JSON.stringify(response));
             // clear choice options
             var secondaryFeastsField = document.getElementById('secondary_feasts');
             secondaryFeastsField.replaceChildren();
@@ -222,19 +256,28 @@
                 opt.value = element.slug;
                 secondaryFeastsField.add(opt);
             });
+            feastsArray = response;
         });
     }
-    // TODO: update feasts also for newly opened pew sheet form
 
     const createFeastBtn = document.getElementById("create-feast");
     createFeastBtn.onclick = () => {
-        dialog.close("Feast creation request submitted!");
-        // wait some time for database update
-        const myTimeout = setTimeout(updateFeasts, 2000);
+        try {
+            dialog.close("Feast creation request submitted!");
+            // wait some time for database update
+            const myTimeout = setTimeout(updateFeasts, 2000);
+        } catch (error) {
+            dialog.close("Feast creation aborted due to errors!");
+        }
     };
 
     dialog.addEventListener('close', function (e) {
         e.preventDefault();
         console.log(dialog.returnValue);
     });  
+
+    // load secondary feast options on init
+    (() => {
+        updateFeasts();
+    })();
 </script>

--- a/templates/serviceForm.html
+++ b/templates/serviceForm.html
@@ -138,7 +138,7 @@
     <div class="row mb-3">
         {{ form.anthem_translation.label(class='col-sm-2 col-form-label') }}
         <div class="col-sm-5">
-            {{ form.anthem_translation(class='form-control') }}
+            {{ form.anthem_translation(class='form-select') }}
             {% if form.anthem_translation.errors %}
                 {% for error in form.anthem_translation.errors %}
                     <small class="font-small text-danger">

--- a/templates/serviceForm.html
+++ b/templates/serviceForm.html
@@ -1,16 +1,12 @@
 <dialog id="feast-dialog">
     <form method="get" action="{{ url_for('create_feast') }}">
-      <p>
-        <label for="feast-name">Feast Name:</label>
-        <input type="text" id="feast-name">
-      </p>
+        {% include "createFeast.html" %}
       <div>
         <button id="cancel" type="reset">Cancel</button>
         <input id="create-feast" type="submit" value="Create Feast">
       </div>
     </form>
 </dialog>
-
 <form action="{{ url_for('pew_sheet_create_view') }}"
       class="px-5">
     <div class="row mb-3">

--- a/templates/serviceForm.html
+++ b/templates/serviceForm.html
@@ -122,11 +122,11 @@
     </div>
 
     <div class="row mb-3">
-        {{ form.anthem_title.label(class='col-sm-2 col-form-label') }}
+        {{ form.anthem_group.title.label(class='col-sm-2 col-form-label') }}
         <div class="col-sm-5">
-            {{ form.anthem_title(class='form-control') }}
-            {% if form.anthem_title.errors %}
-                {% for error in form.anthem_title.errors %}
+            {{ form.anthem_group.title(class='form-control') }}
+            {% if form.anthem_group.title.errors %}
+                {% for error in form.anthem_group.title.errors %}
                     <small class="font-small text-danger">
                         {{ error }}
                     </small>
@@ -136,11 +136,11 @@
     </div>
 
     <div class="row mb-3">
-        {{ form.anthem_translation.label(class='col-sm-2 col-form-label') }}
+        {{ form.anthem_group.translation.label(class='col-sm-2 col-form-label') }}
         <div class="col-sm-5">
-            {{ form.anthem_translation(class='form-select') }}
-            {% if form.anthem_translation.errors %}
-                {% for error in form.anthem_translation.errors %}
+            {{ form.anthem_group.translation(class='form-select') }}
+            {% if form.anthem_group.translation.errors %}
+                {% for error in form.anthem_group.translation.errors %}
                     <small class="font-small text-danger">
                         {{ error }}
                     </small>
@@ -150,11 +150,11 @@
     </div>
 
     <div class="row mb-3">
-        {{ form.anthem_composer.label(class='col-sm-2 col-form-label') }}
+        {{ form.anthem_group.composer.label(class='col-sm-2 col-form-label') }}
         <div class="col-sm-5">
-            {{ form.anthem_composer(class='form-control') }}
-            {% if form.anthem_composer.errors %}
-                {% for error in form.anthem_composer.errors %}
+            {{ form.anthem_group.composer(class='form-control') }}
+            {% if form.anthem_group.composer.errors %}
+                {% for error in form.anthem_group.composer.errors %}
                     <small class="font-small text-danger">
                         {{ error }}
                     </small>
@@ -164,11 +164,11 @@
     </div>
 
     <div class="row mb-3">
-        {{ form.anthem_lyrics.label(class='col-sm-2 col-form-label') }}
+        {{ form.anthem_group.lyrics.label(class='col-sm-2 col-form-label') }}
         <div class="col-sm-5">
-            {{ form.anthem_lyrics(class='form-control') }}
-            {% if form.anthem_lyrics.errors %}
-                {% for error in form.anthem_lyrics.errors %}
+            {{ form.anthem_group.lyrics(class='form-control') }}
+            {% if form.anthem_group.lyrics.errors %}
+                {% for error in form.anthem_group.lyrics.errors %}
                     <small class="font-small text-danger">
                         {{ error }}
                     </small>

--- a/tests/test_pypew.py
+++ b/tests/test_pypew.py
@@ -77,7 +77,8 @@ class TestModels(unittest.TestCase):
                   category='Hymn',
                   composer=None,
                   lyrics=None,
-                  ref='NEH: 1a')
+                  ref='NEH: 1a',
+                  translation = 'Words/translation available at NEH: 1a, Creator of the stars of night')
         )
 
     def test_neh_lookup_unsuccessful(self):

--- a/tests/test_pypew.py
+++ b/tests/test_pypew.py
@@ -224,7 +224,7 @@ class TestViews(unittest.TestCase):
                     'introit_hymn': '',
                     'offertory_hymn': '',
                     'recessional_hymn': '',
-                    'anthem_translation': ''
+                    'anthem_group-translation': ''
                 }
             )
         )

--- a/tests/test_pypew.py
+++ b/tests/test_pypew.py
@@ -224,6 +224,7 @@ class TestViews(unittest.TestCase):
                     'introit_hymn': '',
                     'offertory_hymn': '',
                     'recessional_hymn': '',
+                    'anthem_translation': ''
                 }
             )
         )

--- a/utils.py
+++ b/utils.py
@@ -75,3 +75,7 @@ def advent(year: int) -> date:
         return christmas - timedelta(days=christmas_dow + 7*3)
     else:
         return christmas - timedelta(7 * 4)
+
+def formatFeastName(name: str) -> str:
+    nameComponents = name.split()
+    return ('-').join(nameComponents)

--- a/views/pew_sheet_views.py
+++ b/views/pew_sheet_views.py
@@ -7,7 +7,7 @@ from flask import (flash, make_response, redirect, render_template, request,
                    send_file, session, url_for)
 from werkzeug.datastructures import ImmutableMultiDict
 
-from forms import PewSheetForm
+from forms import PewSheetForm, FeastForm
 from models import Feast, Service
 from utils import cache_dir, logger
 
@@ -17,10 +17,13 @@ dotenv.load_dotenv()
 COOKIE_NAME = os.environ.get('COOKIE_NAME', 'previousPewSheets')
 
 def create_feast():
-    print('you are about to create a feast')
+    print('Into feast creation...')
+    feastForm = FeastForm(request.args)
+    Feast.to_yaml(feastForm)
     return make_response('', 204)
 
 def pew_sheet_create_view():
+    feastForm = FeastForm(request.args)
     form = PewSheetForm(request.args)
     if not form.primary_feast.data:
         form.primary_feast.data = Feast.next().slug
@@ -52,10 +55,9 @@ def pew_sheet_create_view():
             pass
 
     previous_services.sort(key=lambda args_service: args_service[1].date)
-
     return render_template(
         'pewSheet.html', form=form, service=service,
-        previous_services=previous_services
+        previous_services=previous_services, feastForm=feastForm
     )
 
 

--- a/views/pew_sheet_views.py
+++ b/views/pew_sheet_views.py
@@ -17,12 +17,24 @@ dotenv.load_dotenv()
 COOKIE_NAME = os.environ.get('COOKIE_NAME', 'previousPewSheets')
 
 def create_feast():
-    print('Into feast creation...')
     feastForm = FeastForm(request.args)
+    # not working
+    # if not feastForm.validate_on_submit():
+    #     print('Form not validated successfully')
+    #     flash(
+    #         'Sorry, I could not create a service from that information. '
+    #         'Please check the values that you provided.',
+    #         'danger')
+    #     for k, es in feastForm.errors.items():
+    #         for e in es:
+    #             flash(f'{k}: {e}', 'danger')
+    #     return make_response('', 400)
+    print('Into feast creation...')
     Feast.to_yaml(feastForm)
     return make_response('', 204)
 
 def pew_sheet_create_view():
+    feastFormFields = ["name", "month", "day", "collect", "introit", "offertory", "tract", "gradual"]
     feastForm = FeastForm(request.args)
     form = PewSheetForm(request.args)
     if not form.primary_feast.data:
@@ -57,7 +69,7 @@ def pew_sheet_create_view():
     previous_services.sort(key=lambda args_service: args_service[1].date)
     return render_template(
         'pewSheet.html', form=form, service=service,
-        previous_services=previous_services, feastForm=feastForm
+        previous_services=previous_services, feastForm=feastForm, feastFormFields=feastFormFields
     )
 
 

--- a/views/pew_sheet_views.py
+++ b/views/pew_sheet_views.py
@@ -18,23 +18,12 @@ COOKIE_NAME = os.environ.get('COOKIE_NAME', 'previousPewSheets')
 
 def create_feast():
     feastForm = FeastForm(request.args)
-    # not working
-    # if not feastForm.validate_on_submit():
-    #     print('Form not validated successfully')
-    #     flash(
-    #         'Sorry, I could not create a service from that information. '
-    #         'Please check the values that you provided.',
-    #         'danger')
-    #     for k, es in feastForm.errors.items():
-    #         for e in es:
-    #             flash(f'{k}: {e}', 'danger')
-    #     return make_response('', 400)
     print('Into feast creation...')
     Feast.to_yaml(feastForm)
     return make_response('', 204)
 
 def pew_sheet_create_view():
-    feastFormFields = ["name", "month", "day", "collect", "introit", "offertory", "tract", "gradual"]
+    feastFormFields = ["name", "month", "day", "collect", "introit", "offertory", "tract", "gradual", "alleluia"]
     feastForm = FeastForm(request.args)
     form = PewSheetForm(request.args)
     if not form.primary_feast.data:


### PR DESCRIPTION
Functionality for adding feast manually via modal as of #50:
User can add a feast by clicking a button on the PewSheet form which opens a modal. Automatic detection of possible duplicates. After successful form submit, the feast is available in the secondary feast field.
Known issue: Feast form validation not possible.